### PR TITLE
SysV-Init-style init-script for Fedora

### DIFF
--- a/mbpfan.init.fedora
+++ b/mbpfan.init.fedora
@@ -1,0 +1,101 @@
+#!/bin/sh
+#
+# mbpfan Start the mbpfan daemon
+#
+# chkconfig:   2 3 4 5 15 85
+# description: Start the mbpfan daemon
+
+### BEGIN INIT INFO
+# Provides:          mbpfan
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: mbpfan initscript
+# Description:       Start the mbpfan daemon
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec="/usr/sbin/mbpfan"
+prog="mbpfan"
+
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+lockfile=/var/lock/subsys/$prog
+
+start() {
+    [ -x $exec ] || exit 5
+    echo -n $"Starting $prog: "
+    daemon $exec
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    # run checks to determine if the service is running or use generic status
+    status $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+exit $?
+


### PR DESCRIPTION
Hi there! Just discovered your nice project, had to make some changes to make it work on my MBP 15" (2009) with Fedora 17 (3.4.4 kernel).

This first pull request just contains the init-script for Fedora.

The rest of the changes will follow; I'm plan to move the (currently static) values into an external configfile first (as my changes for my MBP seem to differ from yours).

Just one question:
In my case, the fans _never_ gained manual control, I had to write a value of "1" into the "fanX_manual" nodes.. Also (and maybe because of this?) I had to change the path for the actual control from "fanX_min" to "fanX_output" - as the values in "fanX_min" didn't seem to have any effect in manual mode - it seems to work for you in automatic mode, though, but as the automatic mode always sets my fans to "6000" (in Fedora at least), I had to change the path to set the actual speed - instead of just modifying the "fanX_min" values.

For the "1" to active the manual mode, also see this article from Allan McRae:
http://allanmcrae.com/2010/05/simple-macbook-pro-fan-daemon/

Thanks a lot for this, I was nearly going crazy because both of my fans were spinning at 6000 all the time.
- Cerial
