### PR TITLE
Change upstart to respawn forever

### DIFF
--- a/mbpfan.upstart
+++ b/mbpfan.upstart
@@ -7,7 +7,6 @@ start on filesystem or runlevel [2345]
 stop on runlevel [!2345]
 
 respawn
-respawn limit 10 5
 umask 022
 
 console log


### PR DESCRIPTION
The daemon should never stop re-spawning. The current retry count was not enough to get the daemon running on my machine.
