### PR TITLE
Honor speed limits provided by kernel.

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -7,6 +7,18 @@ extern int verbose;
 extern const char* PROGRAM_NAME;
 extern const char* PROGRAM_PID;
 
+struct s_step {
+    int step_up;
+    int step_down;
+};
+typedef struct s_step t_step;
+
+struct s_fanlimits {
+    int max_fan_speed;
+    int min_fan_speed;
+};
+typedef struct s_fanlimits t_fanlimits;
+
 struct s_sensors {
     char* path;
     unsigned int temperature;
@@ -17,6 +29,9 @@ struct s_fans {
     char* path;
     char* fan_output_path;
     char* fan_manual_path;
+    t_fanlimits fanlimits;
+    t_step stepinfo;
+    int curr_fan_speed;
     struct s_fans *next;
 };
 

--- a/src/mbpfan.h
+++ b/src/mbpfan.h
@@ -89,7 +89,7 @@ void set_fans_auto(t_fans *fans);
  * Given a list of sensors with associated fans
  * Change their speed
  */
-void set_fan_speed(t_fans* fans, int speed);
+void control_fan(t_fans* fans);
 
 /**
  *  Return average CPU temp in degrees (ceiling)


### PR DESCRIPTION
Just to let you know that this is just a request for comments on issues I'm having
with my Mac which has two fans. I need each fan has its own speed limits probably
provided by kernel. 

When used on dual fan Macbooks, mpbfan sets both fan speed limits to
the same min_fan_speed/max_fan_speed values specified in mbpfan.conf.
Instead of using the same global speed for all fans in machine honor
the fan speed values provided by "fanNmax","fanNmin" attributes in
sysfs file system.

Signed-off-by: Cihangir Akturk <cakturk@gmail.com>