### PR TITLE
Fix buffer overflow in sprintf

### DIFF
--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -129,7 +129,7 @@ t_sensors *retrieve_sensors()
         int counter;
         for (counter = 0; counter < 10; counter++) {
 
-            char hwmon_path[strlen(path_begin)+1];
+            char hwmon_path[strlen(path_begin)+3];
 
             sprintf(hwmon_path, "%s%d", path_begin, counter);
 

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -129,7 +129,7 @@ t_sensors *retrieve_sensors()
         int counter;
         for (counter = 0; counter < 10; counter++) {
 
-            char hwmon_path[strlen(path_begin)+3];
+            char hwmon_path[strlen(path_begin)+2];
 
             sprintf(hwmon_path, "%s%d", path_begin, counter);
 


### PR DESCRIPTION
This should fix #72 

The +3 should be for 1 null byte and 2 integers.