### PR TITLE
Bump max fan speed to 6500

### DIFF
--- a/mbpfan.conf
+++ b/mbpfan.conf
@@ -1,6 +1,6 @@
 [general]
 min_fan_speed = 2000	# default is 2000
-max_fan_speed = 6200	# default is 6200
+max_fan_speed = 6500	# default is 6500
 low_temp = 63			# try ranges 55-63, default is 63
 high_temp = 66			# try ranges 58-66, default is 66
 max_temp = 86			# do not set it > 90, default is 86


### PR DESCRIPTION
On both my MacBookPro11,5 and MacBookAir5,1 both report 6500 as the max fan speed using smcFanControl on OSX.