### PR TITLE
Clang related instruction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Olivier Tilmans
 Yamakaky                <yamakaky AT gmail DOT com>
 Yi Yang                 <ahyangyi AT gmail DOT com>
 Herminio Hernandez Jr   <herminio.hernandezjr AT gmail DOT com>
+Robert Musial           <rmusial AT fastmail DOT com>
 
 
 ORIGINARY AUTHORS

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ README.md to /usr/share/doc/mbpfan, and mbpfan.8.gz to /usr/share/man/man8
 Compile with Clang
 -------------------------
 Edit the 'Makefile' and replace G++ with clang++
+
 Tested and working with Clang 3.9
 
 Run The Tests (Recommended)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Install with
 It copies mbpfan to /usr/sbin, mbpfan.conf to /etc, 
 README.md to /usr/share/doc/mbpfan, and mbpfan.8.gz to /usr/share/man/man8
 
+Compile with Clang
+-------------------------
+Edit the 'Makefile' and replace G++ with clang++
+Tested and working with Clang 3.9
 
 Run The Tests (Recommended)
 ---------------------------


### PR DESCRIPTION
Thanks for merging my previous PR. I thought rather than just leave the clang info in the PR notes, I'd update the README.md to provide the basic instructions on how to compile with Clang. I have also updated the author info to provide my email address. As new versions of mbpfan and clang are released I will continue to test and update. I also may begin work on updating the Makefile to make it easier to use both.