### PR TITLE
Flush standard out before sleeping in verbose mode.

### DIFF
--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -557,6 +557,7 @@ void mbpfan()
 
         if(verbose) {
             printf("Sleeping for %d seconds\n", polling_interval);
+            fflush(stdout);
 
             if(daemonize) {
                 syslog(LOG_INFO, "Sleeping for %d seconds", polling_interval);


### PR DESCRIPTION
On ubuntu 16.10 with the provided mbpfan.service file, mbpfan runs with the -fv options by default.

This causes output to go to /var/log/syslog, but I noticed the logs there were delayed due to buffering of the standard out i/o stream.  This caused a bunch of logs to appear in /var/log/syslog at random times with wrong timestamps.  

Example:

```
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Old Temp 43: New Temp: 43, Fan Speed: 2000
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Old Temp 43: New Temp: 43, Fan Speed: 2000
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Old Temp 43: New Temp: 43, Fan Speed: 2000
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Old Temp 43: New Temp: 42, Fan Speed: 2000
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Old Temp 42: New Temp: 43, Fan Speed: 2000
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Old Temp 43: New Temp: 42, Fan Speed: 2000
Dec 28 15:20:39 oldmacbook mbpfan[18215]: Sleeping for 7 seconds

Dec 28 15:27:53 oldmacbook mbpfan[18215]: Old Temp 42: New Temp: 42, Fan Speed: 2000
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Old Temp 42: New Temp: 42, Fan Speed: 2000
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Old Temp 42: New Temp: 43, Fan Speed: 2000
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Old Temp 43: New Temp: 43, Fan Speed: 2000
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Old Temp 43: New Temp: 42, Fan Speed: 2000
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Old Temp 42: New Temp: 42, Fan Speed: 2000
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Old Temp 42: New Temp: 42, Fan Speed: 2000
Dec 28 15:27:53 oldmacbook mbpfan[18215]: Sleeping for 7 seconds
```

Adding fflush(stdout) just before sleeping fixes this:

```
Dec 28 16:06:17 oldmacbook mbpfan[20594]: Old Temp 54: New Temp: 53, Fan Speed: 2000
Dec 28 16:06:17 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:06:24 oldmacbook mbpfan[20594]: Old Temp 53: New Temp: 53, Fan Speed: 2000
Dec 28 16:06:24 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:06:31 oldmacbook mbpfan[20594]: Old Temp 53: New Temp: 53, Fan Speed: 2000
Dec 28 16:06:31 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:06:38 oldmacbook mbpfan[20594]: Old Temp 53: New Temp: 53, Fan Speed: 2000
Dec 28 16:06:38 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:06:45 oldmacbook mbpfan[20594]: Old Temp 53: New Temp: 56, Fan Speed: 2000
Dec 28 16:06:45 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:06:52 oldmacbook mbpfan[20594]: Old Temp 56: New Temp: 52, Fan Speed: 2000
Dec 28 16:06:52 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:06:59 oldmacbook mbpfan[20594]: Old Temp 52: New Temp: 52, Fan Speed: 2000
Dec 28 16:06:59 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:07:06 oldmacbook mbpfan[20594]: Old Temp 52: New Temp: 52, Fan Speed: 2000
Dec 28 16:07:06 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
Dec 28 16:07:13 oldmacbook mbpfan[20594]: Old Temp 52: New Temp: 52, Fan Speed: 2000
Dec 28 16:07:13 oldmacbook mbpfan[20594]: Sleeping for 7 seconds
```