### PR TITLE
Add Macmini5,3 to supported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This section reports the iMac/Mac-mini models where mbpfan was tested successful
 - iMac 12,1 21.5" (Intel i7 - Linux 4.6.4)
 - iMac 5,1 17" (Intel T7400 (Core 2 Duo) - Linux 14.04 Ubuntu)
 - Mac Mini 2,1 (Core 2 Duo - Linux 4.4.0)
+- Mac Mini 5,3 (Core i7 2.0 - Linux 4.4.0 elementary/Ubuntu)
 - Mac Mini 6,1 (Core i7 2.3 - Linux 4.7.3-4-ck Archlinux)
 
 Warning


### PR DESCRIPTION
```
sudo dmidecode -s system-product-name
Macmini5,3
```

```
uname -a
Linux elementaty-mini 4.4.0-59-generic #80-Ubuntu SMP Fri Jan 6 17:47:47 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
```

```
sudo make tests
make install
make[1]: Entering directory '/home/wmoore/Source/mbpfan'
make
make[2]: Entering directory '/home/wmoore/Source/mbpfan'
Linking...
g++  -g -lm  src/settings.o src/daemon.o src/mbpfan.o src/main.o src/minunit.o src/strmap.o -lm -o bin/mbpfan
make[2]: Leaving directory '/home/wmoore/Source/mbpfan'
install -d /usr/sbin
install -d /etc
install -d /lib/systemd/system
install -d /usr/share/doc/mbpfan
install bin/mbpfan /usr/sbin
install -m644 mbpfan.conf /etc
install -m644 README.md /usr/share/doc/mbpfan
install -d /usr/share/man/man8
install -m644 mbpfan.8.gz /usr/share/man/man8

******************
INSTALL COMPLETED
******************

A configuration file has been copied (might overwrite existing file) to /etc/mbpfan.conf.
See README.md file to have mbpfan automatically started at system boot.

Please run the tests now with the command
sudo make tests

make[1]: Leaving directory '/home/wmoore/Source/mbpfan'
/usr/sbin/mbpfan -f -v -t
Starting the tests..
It is normal for them to take a bit to finish.
Detected kernel version: 4
Detected kernel minor revision: 4
Detected kernel version: 4
Detected kernel minor revision: 4
Using new sensor path for kernel >= 3.0.15
Found hwmon path at /sys/devices/platform/coretemp.0/hwmon/hwmon0/temp
Found 5 sensors
Found 1 fans
Detected kernel version: 4
Detected kernel minor revision: 4
Using new sensor path for kernel >= 3.0.15
Found hwmon path at /sys/devices/platform/coretemp.0/hwmon/hwmon0/temp
Found 5 sensors
Testing the _supplied_ mbpfan.conf (not the one you are using)..
ALL TESTS PASSED
Tests run: 8
```