### PR TITLE
Makefile clean up, and C cleanup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Olivier Tilmans
 Yamakaky                <yamakaky AT gmail DOT com>
 Yi Yang                 <ahyangyi AT gmail DOT com>
 Herminio Hernandez Jr   <herminio.hernandezjr AT gmail DOT com>
-Robert Musial           <rmusial AT fastmail DOT com>
+Robert Musial           <rmmm AT member DOT fsf DOT org>
 
 
 ORIGINARY AUTHORS

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Olivier Tilmans
 Yamakaky                <yamakaky AT gmail DOT com>
 Yi Yang                 <ahyangyi AT gmail DOT com>
 Herminio Hernandez Jr   <herminio.hernandezjr AT gmail DOT com>
-Robert Musial           <rmmm AT gnu DOT org>
+Robert Musial           <rmusial AT fastmail DOT com>
 
 
 ORIGINARY AUTHORS

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Olivier Tilmans
 Yamakaky                <yamakaky AT gmail DOT com>
 Yi Yang                 <ahyangyi AT gmail DOT com>
 Herminio Hernandez Jr   <herminio.hernandezjr AT gmail DOT com>
-Robert Musial           <rmusial AT fastmail DOT com>
+Robert Musial           <rmmm AT gnu DOT org>
 
 
 ORIGINARY AUTHORS

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Olivier Tilmans
 Yamakaky                <yamakaky AT gmail DOT com>
 Yi Yang                 <ahyangyi AT gmail DOT com>
 Herminio Hernandez Jr   <herminio.hernandezjr AT gmail DOT com>
-Robert Musial           <rmusial AT fastmail DOT com>
+Robert Musial           <rmmm@member.fsf.org>
 
 
 ORIGINARY AUTHORS

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Olivier Tilmans
 Yamakaky                <yamakaky AT gmail DOT com>
 Yi Yang                 <ahyangyi AT gmail DOT com>
 Herminio Hernandez Jr   <herminio.hernandezjr AT gmail DOT com>
-Robert Musial           <rmmm@member.fsf.org>
+Robert Musial           <rmusial AT fastmail DOT com>
 
 
 ORIGINARY AUTHORS

--- a/Makefile
+++ b/Makefile
@@ -1,60 +1,38 @@
-COMPILER=G++
+COMPILER=cc
 
-# todo: object files into output path, processing c / c++ files in the same time (?), nested directories for source files (?)
 C = c
 OUTPUT_PATH = bin/
 SOURCE_PATH = src/
-EXE = bin/mbpfan
+BIN = bin/mbpfan
 CONF = mbpfan.conf
 DOC = README.md
 MAN = mbpfan.8.gz
 
-ifeq ($(COMPILER), G++)
-  ifeq ($(OS),Windows_NT)
-    OBJ = obj
-  else
-    OBJ = o
-  endif
-  COPT = 
-  CCMD = g++
-  OBJFLAG = -o
-  EXEFLAG = -o
-# INCLUDES = -I../.includes
-  INCLUDES =
-# LIBS = -lgc
-  LIBS = -lm
-# LIBPATH = -L../gc/.libs
-  LIBPATH =
-  CPPFLAGS +=  $(COPT) -g $(INCLUDES) #-Wall
-  LDFLAGS += $(LIBPATH) -g $(LIBS) #-Wall
-  DEP = dep
-else
-  OBJ = obj
-  COPT = /O2
-  CCMD = cl
-  OBJFLAG = /Fo
-  EXEFLAG = /Fe
-# INCLUDES = /I..\\.includes
-  INCLUDES =
-# LIBS = ..\\.libs\\libgc.lib
-  LIBS =
-  CPPFLAGS = $(COPT) /DEBUG $(INCLUDES)
-  LDFLAGS = /DEBUG
-endif
+COPT = 
+CC = cc
+OBJFLAG = -o
+BINFLAG = -o
+INCLUDES =
+LIBS = -lm
+LIBPATH =
+CFLAGS +=  $(COPT) -g $(INCLUDES) #-Wall
+LDFLAGS += $(LIBPATH) -g $(LIBS) #-Wall
+DEP = dep
+
 
 OBJS := $(patsubst %.$(C),%.$(OBJ),$(wildcard $(SOURCE_PATH)*.$(C)))
 
 %.$(OBJ):%.$(C)
 	mkdir -p bin
 	@echo Compiling $(basename $<)...
-	$(CCMD) -c $(CPPFLAGS) $(CXXFLAGS) $< $(OBJFLAG)$@
+	$(CC) -c $(CFLAGS) $< $(OBJFLAG)$@
 
 all: $(OBJS)
 	@echo Linking...
-	$(CCMD) $(LDFLAGS) $^ $(LIBS) $(EXEFLAG) $(EXE)
+	$(CC) $(LDFLAGS) $^ $(LIBS) $(BINFLAG) $(BIN)
 
 clean:
-	rm -rf $(SOURCE_PATH)*.$(OBJ) $(EXE)
+	rm -rf $(SOURCE_PATH)*.$(OBJ) $(BIN)
 
 tests:
 	make install
@@ -73,7 +51,7 @@ install:
 	install -d $(DESTDIR)/etc
 	install -d $(DESTDIR)/lib/systemd/system
 	install -d $(DESTDIR)/usr/share/doc/mbpfan
-	install $(EXE) $(DESTDIR)/usr/sbin
+	install $(BIN) $(DESTDIR)/usr/sbin
 	install -m644 $(CONF) $(DESTDIR)/etc
 	install -m644 $(DOC) $(DESTDIR)/usr/share/doc/mbpfan
 	install -d $(DESTDIR)/usr/share/man/man8

--- a/README.md
+++ b/README.md
@@ -112,22 +112,8 @@ README.md to /usr/share/doc/mbpfan, and mbpfan.8.gz to /usr/share/man/man8
 
 Run the tests now, see two sections below.
 
-If you would like to compile with Clang instead of GCC, see the next section.
-
-Compile with Clang (experimental)
----------------------------------
-We are providing an initial experimental support for [Clang and LLVM](http://clang.llvm.org/).
-Please go to the next section if you are following a standard installation procedure (most people do).
-
-Edit the 'Makefile' and replace G++ with clang++
-
-Please run
-
-    make clean
-
-Before attempting to compile again with Clang.
-
-Tested and working with Clang 3.8 and 3.9.
+If you would like to compile with Clang instead of GCC, simply set your system's
+default compiler to be Clang (tested with Clang 3.8)
 
 
 Run The Tests (Recommended)

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -2,7 +2,7 @@
  *  Copyright (C) 2012  Peter Lombardo <http://peterlombardo.wikidot.com/linux-daemon-in-c>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee>
- *  Modifications (2017-present) by Robert Musial <rmmm@member.fsf.org>
+ *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -2,7 +2,7 @@
  *  Copyright (C) 2012  Peter Lombardo <http://peterlombardo.wikidot.com/linux-daemon-in-c>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee>
- *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
+ *  Modifications (2017-present) by Robert Musial <rmmm@member.fsf.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -2,6 +2,7 @@
  *  Copyright (C) 2012  Peter Lombardo <http://peterlombardo.wikidot.com/linux-daemon-in-c>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee>
+ *  Modifications (2017-present) by Robert Musial <rmmm@gnu.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,6 +21,7 @@
 #include <sys/stat.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <syslog.h>
@@ -77,7 +79,7 @@ static void cleanup_and_exit(int exit_code)
 	delete_pid();
 	set_fans_auto(fans);
 	
-	s_fans *next_fan;
+	struct s_fans *next_fan;
 	while (fans != NULL) {
 		next_fan = fans->next;
 		free(fans->fan_output_path);
@@ -86,7 +88,7 @@ static void cleanup_and_exit(int exit_code)
 		fans = next_fan;
 	}
 
-	s_sensors *next_sensor;
+	struct s_sensors *next_sensor;
 	while (sensors != NULL) {
 		next_sensor = sensors->next;
 		free(sensors->path);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -2,7 +2,7 @@
  *  Copyright (C) 2012  Peter Lombardo <http://peterlombardo.wikidot.com/linux-daemon-in-c>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee>
- *  Modifications (2017-present) by Robert Musial <rmmm@gnu.org>
+ *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright (C) (2012-present) Daniel Graziotin <daniel@ineed.coffee>
- *  Modifications (2017-present) by Robert Musial <rmmm@member.fsf.org>
+ *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 /**
  *  Copyright (C) (2012-present) Daniel Graziotin <daniel@ineed.coffee>
+ *  Modifications (2017-present) by Robert Musial <rmmm@gnu.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,6 +22,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <syslog.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <errno.h>

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright (C) (2012-present) Daniel Graziotin <daniel@ineed.coffee>
- *  Modifications (2017-present) by Robert Musial <rmmm@gnu.org>
+ *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright (C) (2012-present) Daniel Graziotin <daniel@ineed.coffee>
- *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
+ *  Modifications (2017-present) by Robert Musial <rmmm@member.fsf.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -4,7 +4,7 @@
  *  Modifications by Rafael Vega <rvega@elsoftwarehamuerto.org>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee> [CURRENT MAINTAINER]
- *  Modifications (2017-present) by Robert Musial <rmmm@gnu.org>
+ *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -4,7 +4,7 @@
  *  Modifications by Rafael Vega <rvega@elsoftwarehamuerto.org>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee> [CURRENT MAINTAINER]
- *  Modifications (2017-present) by Robert Musial <rmmm@member.fsf.org>
+ *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -4,6 +4,7 @@
  *  Modifications by Rafael Vega <rvega@elsoftwarehamuerto.org>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee> [CURRENT MAINTAINER]
+ *  Modifications (2017-present) by Robert Musial <rmmm@gnu.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,6 +33,7 @@
 #include <string.h>
 #include <math.h>
 #include <syslog.h>
+#include <stdbool.h>
 #include <sys/utsname.h>
 #include <sys/errno.h>
 #include "mbpfan.h"

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -4,7 +4,7 @@
  *  Modifications by Rafael Vega <rvega@elsoftwarehamuerto.org>
  *  Modifications (2012) by Ismail Khatib <ikhatib@gmail.com>
  *  Modifications (2012-present) by Daniel Graziotin <daniel@ineed.coffee> [CURRENT MAINTAINER]
- *  Modifications (2017-present) by Robert Musial <rmusial@fastmail.com>
+ *  Modifications (2017-present) by Robert Musial <rmmm@member.fsf.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/minunit.c
+++ b/src/minunit.c
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <limits.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <sys/utsname.h>
 #include "global.h"
 #include "mbpfan.h"


### PR DESCRIPTION
Hello Daniel,

Where we left off I was able to get mbpfan to compile under clang by
adding the missing return to the function in minunit.c. Our next goal
was to clean up the Makefile so you didn't have to edit it to use a
different compiler, and also clean it up since it was using a C++
compiler when all the code is C.

I think I figured out why it was using a C++ compiler. First the old C
standard didn't support boolean data types. The new standard does
but you have to include stdbool.h. So that was added to the
appropriate .c files. Second, C needs an explicit type def, and daemon.c
did not have that, so the appropriate structs were added.

Finally the Windows NT stuff was removed from the Makefile, and I have
updated my personal information.

The Makefile still needs work before it is pretty, but it works in GCC, Clang, Debian,
Ubuntu, and Trsiquel. I will test CentOS shortly.