### PR TITLE
Detect minimum and maximum fan speeds

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -98,6 +98,48 @@ void check_requirements()
 }
 
 
+static int read_value(const char *path)
+{
+    int value = -1;
+    FILE *file = fopen(path, "r");
+    if (file != NULL) {
+        fscanf(file, "%d", &value);
+        fclose(file);
+    }
+    return value;
+}
+
+
+static void set_defaults(void)
+{
+    int i;
+    char *path;
+    int value;
+    for (i = 1; i <= 10; ++i) {
+        path = smprintf("%s/fan%d_min", APPLESMC_PATH, i);
+        value = read_value(path);
+        if (value != -1 && (min_fan_speed == -1 || value < min_fan_speed)) {
+            min_fan_speed = value;
+        }
+        free(path);
+
+        path = smprintf("%s/fan%d_max", APPLESMC_PATH, i);
+        value = read_value(path);
+        if (value != -1 && (max_fan_speed == -1 || value > max_fan_speed)) {
+            max_fan_speed = value;
+        }
+        free(path);
+    }
+
+    if (min_fan_speed == -1) {
+        min_fan_speed = 2000;
+    }
+    if (max_fan_speed == -1) {
+        max_fan_speed = 6200;
+    }
+}
+
+
 int main(int argc, char *argv[])
 {
 
@@ -133,6 +175,7 @@ int main(int argc, char *argv[])
 
 
     check_requirements();
+    set_defaults();
 
     // pointer to mbpfan() function in mbpfan.c
     void (*fan_control)() = mbpfan;

--- a/src/mbpfan.c
+++ b/src/mbpfan.c
@@ -46,8 +46,9 @@
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #define max(a,b) ((a) > (b) ? (a) : (b))
 
-int min_fan_speed = 2000;
-int max_fan_speed = 6200;
+// TODO: per-fan minimum and maximum?
+int min_fan_speed = -1;
+int max_fan_speed = -1;
 
 /* temperature thresholds
  * low_temp - temperature below which fan speed will be at minimum
@@ -63,8 +64,7 @@ t_sensors* sensors = NULL;
 t_fans* fans = NULL;
 
 
-static char *smprintf(const char *fmt, ...) __attribute__((format (printf, 1, 2)));
-static char *smprintf(const char *fmt, ...)
+char *smprintf(const char *fmt, ...)
 {
     char *buf;
     int cnt;
@@ -497,6 +497,17 @@ void mbpfan()
     int step_up, step_down;
 
     retrieve_settings(NULL);
+
+    if (min_fan_speed > max_fan_speed) {
+        syslog(LOG_INFO, "Invalid fan speeds: %d %d", min_fan_speed, max_fan_speed);
+        printf("Invalid fan speeds: %d %d\n", min_fan_speed, max_fan_speed);
+        exit(EXIT_FAILURE);
+    }
+    if (low_temp > high_temp || high_temp > max_temp) {
+        syslog(LOG_INFO, "Invalid temperatures: %d %d %d", low_temp, high_temp, max_temp);
+        printf("Invalid temperatures: %d %d %d\n", low_temp, high_temp, max_temp);
+        exit(EXIT_FAILURE);
+    }
 
     sensors = retrieve_sensors();
     fans = retrieve_fans();

--- a/src/mbpfan.h
+++ b/src/mbpfan.h
@@ -43,6 +43,8 @@ typedef struct s_sensors t_sensors;
 struct s_fans;
 typedef struct s_fans t_fans;
 
+char *smprintf(const char *fmt, ...) __attribute__((format (printf, 1, 2)));
+
 /**
  * Return true if the kernel is < 3.15.0
  */


### PR DESCRIPTION
Default to previous values if detection fails.  Configuration can
still override these values.  Fixes #114.