### PR TITLE
RedHat/CentOS spec file to generate RPMS

### DIFF
--- a/mbpfan.conf
+++ b/mbpfan.conf
@@ -1,7 +1,7 @@
 [general]
 # see https://ineed.coffee/3838/a-beginners-tutorial-for-mbpfan-under-ubuntu for the values
-min_fan_speed = 2000	# put the *lowest* value of "cat /sys/devices/platform/applesmc.768/fan*_min"
-max_fan_speed = 6200	# put the *highest* value of "cat /sys/devices/platform/applesmc.768/fan*_max"
+#min_fan_speed = 2000	# put the *lowest* value of "cat /sys/devices/platform/applesmc.768/fan*_min"
+#max_fan_speed = 6200	# put the *highest* value of "cat /sys/devices/platform/applesmc.768/fan*_max"
 low_temp = 63			# try ranges 55-63, default is 63
 high_temp = 66			# try ranges 58-66, default is 66
 max_temp = 86			# take highest number returned by "cat /sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_max", divide by 1000

--- a/mbpfan.spec
+++ b/mbpfan.spec
@@ -3,7 +3,7 @@ URL:            https://github.com/dgraziotin/mbpfan
 License:        GPLv3
 Group:          System Environment/Daemons
 Version:        %{SOURCE_VERSION}
-Release:        1
+Release:        3
 Summary:        A simple daemon to control fan speed on all MacBook/MacBook Pros (probably all Apple computers) for Linux 3.x.x and 4.x.x
 Source:         v%{version}.tar.gz
 
@@ -35,16 +35,10 @@ rm -rf $RPM_BUILD_ROOT
 
 %post
 %systemd_post mbpfan.service
-# If it is a first installation then autoconfigure daemon
-if [[ ${1} == 1 ]]; then
-  min_fan_speed="$(cat /sys/devices/platform/applesmc.768/fan*_min| uniq| sort |head -1)"
-  max_fan_speed="$(cat /sys/devices/platform/applesmc.768/fan*_max| uniq| sort |tail -1)"
-  let max_temp=$(cat /sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_max|uniq |sort |tail -1)/1000
-  sed -i "s/min_fan_speed = [^\t]\+/min_fan_speed = $min_fan_speed/g" /etc/mbpfan.conf
-  sed -i "s/max_fan_speed = [^\t]\+/max_fan_speed = $max_fan_speed/g" /etc/mbpfan.conf
-  sed -i "s/max_temp = [^\t]\+/max_temp = $max_temp/g" /etc/mbpfan.conf
-fi
-echo "Attention: mbpfan preconfigured with sane values, to run it type:"
+echo "mbpfan will auto detect sane values for min and max fan speeds."
+echo  "If you want to customize these values please edit:"
+echo "/etc/mbpfan.conf"
+echo "To start the daemon now type:"
 echo "systemctl start mbpfan"
 echo "To run also at boot, type:"
 echo "systemctl enable mbpfan"
@@ -63,6 +57,9 @@ echo "systemctl enable mbpfan"
 /usr/lib/systemd/system/mbpfan.service
 
 %changelog
+* Mon Sep 10 2018 Michele Codutti <codutti@gmail.com> - 2.0.2-3
+- Removed autoconfig with suggested procedure because has been integrated on mbpfan.
+
 * Sun Aug 19 2018 Michele Codutti <codutti@gmail.com> - 2.0.2-2
 - Autoconfig with suggested procedure.
 - Initial packaging


### PR DESCRIPTION
To build it:
rpmbuild -ba rpmbuild/SPECS/mbpfan.spec --define 'SOURCE_VERSION 2.0.2'
It will auto configure the config file using the procedure described here:
https://ineed.coffee/3838/a-beginners-tutorial-for-mbpfan-under-ubuntu/
Maybe you could join this with this pull request:
https://github.com/dgraziotin/mbpfan/pull/154
Il will happily collaborate with Alex Dalshov (myrgy) to merge our commits in one and better organized.